### PR TITLE
Add GPU tests, pytest `gpu` marker

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -1,3 +1,12 @@
 import pytest
 
 pytest_plugins = ["distributed.utils_test", "tests.integration.fixtures"]
+
+
+def pytest_addoption(parser):
+    parser.addoption("--gpu", action="store_true", help="run tests meant for GPU")
+
+
+def pytest_runtest_setup(item):
+    if "gpu" in item.keywords and not item.config.getoption("--gpu"):
+        pytest.skip("need --gpu option to run")

--- a/conftest.py
+++ b/conftest.py
@@ -4,9 +4,9 @@ pytest_plugins = ["distributed.utils_test", "tests.integration.fixtures"]
 
 
 def pytest_addoption(parser):
-    parser.addoption("--gpu", action="store_true", help="run tests meant for GPU")
+    parser.addoption("--rungpu", action="store_true", help="run tests meant for GPU")
 
 
 def pytest_runtest_setup(item):
-    if "gpu" in item.keywords and not item.config.getoption("--gpu"):
-        pytest.skip("need --gpu option to run")
+    if "gpu" in item.keywords and not item.config.getoption("--rungpu"):
+        pytest.skip("need --rungpu option to run")

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,3 @@
+[tool:pytest]
+markers:
+  gpu: marks tests we want to run on GPUs

--- a/tests/integration/test_create.py
+++ b/tests/integration/test_create.py
@@ -8,7 +8,8 @@ from tests.integration.fixtures import skip_if_external_scheduler
 
 
 @skip_if_external_scheduler
-def test_create_from_csv(c, df, temporary_data_file):
+@pytest.mark.parametrize("gpu", [False, pytest.param(True, marks=pytest.mark.gpu)])
+def test_create_from_csv(c, df, temporary_data_file, gpu):
     df.to_csv(temporary_data_file, index=False)
 
     c.sql(
@@ -17,7 +18,8 @@ def test_create_from_csv(c, df, temporary_data_file):
             new_table
         WITH (
             location = '{temporary_data_file}',
-            format = 'csv'
+            format = 'csv',
+            gpu = {gpu}
         )
     """
     )
@@ -28,10 +30,14 @@ def test_create_from_csv(c, df, temporary_data_file):
     """
     ).compute()
 
+    if gpu:
+        result_df = result_df.to_pandas()
+
     assert_frame_equal(result_df, df)
 
 
-def test_cluster_memory(client, c, df):
+@pytest.mark.parametrize("gpu", [False, pytest.param(True, marks=pytest.mark.gpu)])
+def test_cluster_memory(client, c, df, gpu):
     client.publish_dataset(df=dd.from_pandas(df, npartitions=1))
 
     c.sql(
@@ -40,7 +46,8 @@ def test_cluster_memory(client, c, df):
             new_table
         WITH (
             location = 'df',
-            format = 'memory'
+            format = 'memory',
+            gpu = {gpu}
         )
     """
     )
@@ -55,7 +62,8 @@ def test_cluster_memory(client, c, df):
 
 
 @skip_if_external_scheduler
-def test_create_from_csv_persist(c, df, temporary_data_file):
+@pytest.mark.parametrize("gpu", [False, pytest.param(True, marks=pytest.mark.gpu)])
+def test_create_from_csv_persist(c, df, temporary_data_file, gpu):
     df.to_csv(temporary_data_file, index=False)
 
     c.sql(
@@ -65,7 +73,8 @@ def test_create_from_csv_persist(c, df, temporary_data_file):
         WITH (
             location = '{temporary_data_file}',
             format = 'csv',
-            persist = True
+            persist = True,
+            gpu = {gpu}
         )
     """
     )
@@ -75,6 +84,9 @@ def test_create_from_csv_persist(c, df, temporary_data_file):
         SELECT * FROM new_table
     """
     ).compute()
+
+    if gpu:
+        return_df = return_df.to_pandas()
 
     assert_frame_equal(df, return_df)
 
@@ -143,7 +155,20 @@ def test_create_from_query(c, df):
 
 
 @skip_if_external_scheduler
-def test_view_table_persist(c, temporary_data_file, df):
+@pytest.mark.parametrize(
+    "gpu",
+    [
+        False,
+        pytest.param(
+            True,
+            marks=(
+                pytest.mark.gpu,
+                pytest.mark.xfail(reason="to_pandas() changes int precision"),
+            ),
+        ),
+    ],
+)
+def test_view_table_persist(c, temporary_data_file, df, gpu):
     df.to_csv(temporary_data_file, index=False)
     c.sql(
         f"""
@@ -151,7 +176,8 @@ def test_view_table_persist(c, temporary_data_file, df):
             new_table
         WITH (
             location = '{temporary_data_file}',
-            format = 'csv'
+            format = 'csv',
+            gpu = {gpu}
         )
     """
     )
@@ -177,21 +203,27 @@ def test_view_table_persist(c, temporary_data_file, df):
     """
     )
 
-    assert_frame_equal(
-        c.sql("SELECT c FROM count_view").compute(), pd.DataFrame({"c": [700]})
-    )
-    assert_frame_equal(
-        c.sql("SELECT c FROM count_table").compute(), pd.DataFrame({"c": [700]})
-    )
+    from_view = c.sql("SELECT c FROM count_view").compute()
+    from_table = c.sql("SELECT c FROM count_table").compute()
+
+    if gpu:
+        from_view = from_view.to_pandas()
+        from_table = from_table.to_pandas()
+
+    assert_frame_equal(from_view, pd.DataFrame({"c": [700]}))
+    assert_frame_equal(from_table, pd.DataFrame({"c": [700]}))
 
     df.iloc[:10].to_csv(temporary_data_file, index=False)
 
-    assert_frame_equal(
-        c.sql("SELECT c FROM count_view").compute(), pd.DataFrame({"c": [10]})
-    )
-    assert_frame_equal(
-        c.sql("SELECT c FROM count_table").compute(), pd.DataFrame({"c": [700]})
-    )
+    from_view = c.sql("SELECT c FROM count_view").compute()
+    from_table = c.sql("SELECT c FROM count_table").compute()
+
+    if gpu:
+        from_view = from_view.to_pandas()
+        from_table = from_table.to_pandas()
+
+    assert_frame_equal(from_view, pd.DataFrame({"c": [10]}))
+    assert_frame_equal(from_table, pd.DataFrame({"c": [700]}))
 
 
 def test_replace_and_error(c, temporary_data_file, df):


### PR DESCRIPTION
Adds tests for table creation on GPU, along with a pytest marker for GPU tests and a CLI option to enable/disable them.