### PR TITLE
[REVIEW] Fast path when possible for non numeric aggregation

### DIFF
--- a/dask_sql/physical/rel/logical/aggregate.py
+++ b/dask_sql/physical/rel/logical/aggregate.py
@@ -83,7 +83,8 @@ class AggregationSpecification:
                 if dask_cudf is not None and isinstance(series, dask_cudf.Series):
                     return native_agg
 
-                ## If pandas StringDtype return native aggregation
+                ## If pandas StringDtype native aggregation works
+                ## and with ObjectDtype and Nulls native aggregation can fail
                 if isinstance(series, dd.Series) and isinstance(
                     series.dtype, pd.StringDtype
                 ):

--- a/dask_sql/physical/rel/logical/aggregate.py
+++ b/dask_sql/physical/rel/logical/aggregate.py
@@ -56,39 +56,39 @@ class AggregationSpecification:
     Most of the aggregations in SQL are already
     implemented 1:1 in dask and can just be called via their name
     (e.g. AVG is the mean). However sometimes those
-    implemented functions only work well for some native data types.
+    implemented functions only work well for some built-in datatypes.
     This small container class therefore
     can have an additional aggregation function, which is
-    valid for non-supported native types.
+    valid for non-supported built-in types.
     """
 
-    def __init__(self, native_aggregation, custom_aggregation=None):
-        self.native_aggregation = native_aggregation
-        self.custom_aggregation = custom_aggregation or native_aggregation
+    def __init__(self, built_in_aggregation, custom_aggregation=None):
+        self.built_in_aggregation = built_in_aggregation
+        self.custom_aggregation = custom_aggregation or built_in_aggregation
 
     def get_supported_aggregation(self, series):
-        native_agg = self.native_aggregation
+        built_in_aggregation = self.built_in_aggregation
 
         # native_aggreagations work well for all numeric types
         if pd.api.types.is_numeric_dtype(series.dtype):
-            return native_agg
+            return built_in_aggregation
 
         # Todo: Add Categorical when support comes to dask-sql
-        if native_agg in ["min", "max"]:
+        if built_in_aggregation in ["min", "max"]:
             if pd.api.types.is_datetime64_any_dtype(series.dtype):
-                return native_agg
+                return built_in_aggregation
 
             if pd.api.types.is_string_dtype(series.dtype):
                 ## If dask_cudf strings dtype return native aggregation
                 if dask_cudf is not None and isinstance(series, dask_cudf.Series):
-                    return native_agg
+                    return built_in_aggregation
 
                 ## If pandas StringDtype native aggregation works
                 ## and with ObjectDtype and Nulls native aggregation can fail
                 if isinstance(series, dd.Series) and isinstance(
                     series.dtype, pd.StringDtype
                 ):
-                    return native_agg
+                    return built_in_aggregation
 
         return self.custom_aggregation
 

--- a/dask_sql/physical/rel/logical/aggregate.py
+++ b/dask_sql/physical/rel/logical/aggregate.py
@@ -56,10 +56,10 @@ class AggregationSpecification:
     Most of the aggregations in SQL are already
     implemented 1:1 in dask and can just be called via their name
     (e.g. AVG is the mean). However sometimes those
-    implemented functions only work well for some built-in datatypes.
+    implemented functions only work well for some datatypes.
     This small container class therefore
-    can have an additional aggregation function, which is
-    valid for non-supported built-in types.
+    can have an custom aggregation function, which is
+    valid for not supported dtypes.
     """
 
     def __init__(self, built_in_aggregation, custom_aggregation=None):

--- a/dask_sql/physical/rel/logical/aggregate.py
+++ b/dask_sql/physical/rel/logical/aggregate.py
@@ -304,7 +304,7 @@ class LogicalAggregatePlugin(BaseRelPlugin):
                     )
             if isinstance(aggregation_function, AggregationSpecification):
                 dtype = df[input_col].dtype
-                if pd.api.types.is_numeric_dtype(dtype):
+                if pd.api.types.is_numeric_dtype(dtype) or pd.api.types.is_datetime64_any_dtype(dtype):
                     aggregation_function = aggregation_function.numerical_aggregation
                 else:
                     aggregation_function = (

--- a/dask_sql/physical/rel/logical/aggregate.py
+++ b/dask_sql/physical/rel/logical/aggregate.py
@@ -67,9 +67,11 @@ class AggregationSpecification:
         if pd.api.types.is_numeric_dtype(dtype):
             return numeric_agg
 
-        # Todo: Add Categorical and String Checks
+        # Todo: Add Categorical when support comes to dask-sql
         if numeric_agg in ["min", "max", "first"]:
-            if pd.api.types.is_datetime64_any_dtype(dtype):
+            if pd.api.types.is_datetime64_any_dtype(
+                dtype
+            ) or pd.api.types.is_string_dtype(dtype):
                 return numeric_agg
 
         return self.non_numerical_aggregation

--- a/dask_sql/physical/rel/logical/aggregate.py
+++ b/dask_sql/physical/rel/logical/aggregate.py
@@ -64,7 +64,7 @@ class AggregationSpecification:
 
     def __init__(self, native_aggregation, custom_aggregation=None):
         self.native_aggregation = native_aggregation
-        self.custom_aggregation = native_aggregation or custom_aggregation
+        self.custom_aggregation = custom_aggregation or native_aggregation
 
     def get_supported_aggregation(self, series):
         native_agg = self.native_aggregation
@@ -80,7 +80,7 @@ class AggregationSpecification:
 
             if pd.api.types.is_string_dtype(series.dtype):
                 ## If dask_cudf strings dtype return native aggregation
-                if isinstance(series, dask_cudf.Series):
+                if dask_cudf is not None and isinstance(series, dask_cudf.Series):
                     return native_agg
 
                 ## If pandas StringDtype return native aggregation
@@ -88,8 +88,6 @@ class AggregationSpecification:
                     series.dtype, pd.StringDtype
                 ):
                     return native_agg
-
-                return native_agg
 
         return self.custom_aggregation
 

--- a/dask_sql/physical/rel/logical/aggregate.py
+++ b/dask_sql/physical/rel/logical/aggregate.py
@@ -8,11 +8,9 @@ import dask.dataframe as dd
 import pandas as pd
 
 try:
-    import cudf
     import dask_cudf
 except ImportError:
     dask_cudf = None
-    cudf = None
 
 from dask_sql.datacontainer import ColumnContainer, DataContainer
 from dask_sql.physical.rel.base import BaseRelPlugin
@@ -69,7 +67,7 @@ class AggregationSpecification:
     def get_supported_aggregation(self, series):
         built_in_aggregation = self.built_in_aggregation
 
-        # native_aggreagations work well for all numeric types
+        # built-in_aggreagations work well for numeric types
         if pd.api.types.is_numeric_dtype(series.dtype):
             return built_in_aggregation
 
@@ -79,12 +77,12 @@ class AggregationSpecification:
                 return built_in_aggregation
 
             if pd.api.types.is_string_dtype(series.dtype):
-                ## If dask_cudf strings dtype return native aggregation
+                # If dask_cudf strings dtype, return built-in aggregation
                 if dask_cudf is not None and isinstance(series, dask_cudf.Series):
                     return built_in_aggregation
 
-                ## If pandas StringDtype native aggregation works
-                ## and with ObjectDtype and Nulls native aggregation can fail
+                # With pandas StringDtype built-in aggregations work
+                # while with pandas ObjectDtype and Nulls built-in aggregations fail
                 if isinstance(series, dd.Series) and isinstance(
                     series.dtype, pd.StringDtype
                 ):

--- a/dask_sql/physical/rel/logical/aggregate.py
+++ b/dask_sql/physical/rel/logical/aggregate.py
@@ -74,7 +74,7 @@ class AggregationSpecification:
             return native_agg
 
         # Todo: Add Categorical when support comes to dask-sql
-        if native_agg in ["min", "max", "first"]:
+        if native_agg in ["min", "max"]:
             if pd.api.types.is_datetime64_any_dtype(series.dtype):
                 return native_agg
 

--- a/tests/integration/test_compatibility.py
+++ b/tests/integration/test_compatibility.py
@@ -54,6 +54,11 @@ def make_rand_df(size: int, **kwargs):
             r = [f"ssssss{x}" for x in range(10)]
             c = np.random.randint(10, size=size)
             s = np.array([r[x] for x in c])
+        elif dt is pd.StringDtype:
+            r = [f"ssssss{x}" for x in range(10)]
+            c = np.random.randint(10, size=size)
+            s = np.array([r[x] for x in c])
+            s = pd.array(s, dtype="string")
         elif dt is datetime:
             rt = [datetime(2020, 1, 1) + timedelta(days=x) for x in range(10)]
             c = np.random.randint(10, size=size)
@@ -337,7 +342,13 @@ def test_agg_sum_avg():
 
 def test_agg_min_max_no_group_by():
     a = make_rand_df(
-        100, a=(int, 50), b=(str, 50), c=(int, 30), d=(str, 40), e=(float, 40)
+        100,
+        a=(int, 50),
+        b=(str, 50),
+        c=(int, 30),
+        d=(str, 40),
+        e=(float, 40),
+        f=(pd.StringDtype, 40),
     )
     eq_sqlite(
         """
@@ -352,6 +363,8 @@ def test_agg_min_max_no_group_by():
             MAX(d) AS max_d,
             MIN(e) AS min_e,
             MAX(e) AS max_e,
+            MIN(f) as min_f,
+            MAX(f) as max_f,
             MIN(a+e) AS mix_1,
             MIN(a)+MIN(e) AS mix_2
         FROM a
@@ -362,7 +375,13 @@ def test_agg_min_max_no_group_by():
 
 def test_agg_min_max():
     a = make_rand_df(
-        100, a=(int, 50), b=(str, 50), c=(int, 30), d=(str, 40), e=(float, 40)
+        100,
+        a=(int, 50),
+        b=(str, 50),
+        c=(int, 30),
+        d=(str, 40),
+        e=(float, 40),
+        f=(pd.StringDtype, 40),
     )
     eq_sqlite(
         """
@@ -374,6 +393,8 @@ def test_agg_min_max():
             MAX(d) AS max_d,
             MIN(e) AS min_e,
             MAX(e) AS max_e,
+            MIN(f) AS min_f,
+            MAX(f) AS max_f,
             MIN(a+e) AS mix_1,
             MIN(a)+MIN(e) AS mix_2
         FROM a GROUP BY a, b


### PR DESCRIPTION
This PR adds fast path when possible for non numeric aggregation for Min/Max . The PR speeds up aggregations by avoiding the apply based path [here](https://github.com/dask-contrib/dask-sql/blob/4d5f7dd4c133f7f2c584db2492c8f0ef3cba7e31/dask_sql/physical/rel/logical/aggregate.py#L31-L44). 
 

### Motivating Pandas Example 
```python
%%time
df =  pd.DataFrame({'grp_col': np.arange(0,100_000).repeat(3),
                    'p_date': [np.datetime64('2019-08', 'D'),np.datetime64('2019-07', 'D'),np.datetime64('2018-07', 'D')]*100_000,
                     })

df = dd.from_pandas(df, npartitions=4)
dc.create_table('table_1', df)

query = '''
        select 
            MIN(p_date) as f_date
        from 
            table_1
        group by
            grp_col
        '''
res = dc.sql(query)
res.compute()
```
### Mainline
```python
CPU times: user 39.5 s, sys: 451 ms, total: 39.9 s
Wall time: 37.1 s
```

### With this PR (236):
```python
CPU times: user 3.84 s, sys: 180 ms, total: 4.02 s
Wall time: 1.58 s
```