### PR TITLE
Add fast path for multi-column sorting

### DIFF
--- a/dask_sql/physical/utils/sort.py
+++ b/dask_sql/physical/utils/sort.py
@@ -28,7 +28,7 @@ def apply_sort(
         and not any(sort_null_first)
     ):
         try:
-            df = df.sort_values(sort_columns)
+            df = df.sort_values(sort_columns, ignore_index=True)
             return df.persist()
         except ValueError:
             pass

--- a/dask_sql/physical/utils/sort.py
+++ b/dask_sql/physical/utils/sort.py
@@ -3,23 +3,12 @@ from typing import List
 import dask.dataframe as dd
 import pandas as pd
 
-from dask_sql.utils import make_pickable_without_dask_sql, new_temporary_column
+from dask_sql.utils import make_pickable_without_dask_sql
 
 try:
     import dask_cudf
 except ImportError:
     dask_cudf = None
-
-
-def multi_col_sort(
-    df: dd.DataFrame,
-    sort_columns: List[str],
-    sort_ascending: List[bool],
-    sort_null_first: List[bool],
-) -> dd.DataFrame:
-
-    df = df.sort_values(sort_columns)
-    return df.persist()
 
 
 def apply_sort(
@@ -39,7 +28,8 @@ def apply_sort(
         and not any(sort_null_first)
     ):
         try:
-            return multi_col_sort(df, sort_columns, sort_ascending, sort_null_first)
+            df = df.sort_values(sort_columns)
+            return df.persist()
         except ValueError:
             pass
 

--- a/dask_sql/physical/utils/sort.py
+++ b/dask_sql/physical/utils/sort.py
@@ -1,10 +1,14 @@
 from typing import List
 
 import dask.dataframe as dd
-import dask_cudf
 import pandas as pd
 
 from dask_sql.utils import make_pickable_without_dask_sql, new_temporary_column
+
+try:
+    import dask_cudf
+except ImportError:
+    dask_cudf = None
 
 
 def multi_col_sort(
@@ -30,7 +34,8 @@ def apply_sort(
     # multi-column sort implementation.  We check if any sorting/null sorting
     # is required.  If so, we fall back to default sorting implementation
     if (
-        isinstance(df, dask_cudf.DataFrame)
+        dask_cudf is not None
+        and isinstance(df, dask_cudf.DataFrame)
         and all(sort_ascending)
         and not any(sort_null_first)
     ):

--- a/dask_sql/physical/utils/sort.py
+++ b/dask_sql/physical/utils/sort.py
@@ -28,7 +28,6 @@ def apply_sort(
     sort_ascending: List[bool],
     sort_null_first: List[bool],
 ) -> dd.DataFrame:
-
     # Try fast path for multi-column sorting before falling back to
     # sort_partition_func.  Tools like dask-cudf have a limited but fast
     # multi-column sort implementation.  We check if any sorting/null sorting

--- a/dask_sql/physical/utils/sort.py
+++ b/dask_sql/physical/utils/sort.py
@@ -5,6 +5,7 @@ import pandas as pd
 
 from dask_sql.utils import make_pickable_without_dask_sql, new_temporary_column
 
+
 def multi_col_sort(
     df: dd.DataFrame,
     sort_columns: List[str],
@@ -14,6 +15,7 @@ def multi_col_sort(
 
     df = df.sort_values(sort_columns)
     return df.persist()
+
 
 def apply_sort(
     df: dd.DataFrame,
@@ -28,11 +30,9 @@ def apply_sort(
     # is required.  If so, we fall back to default sorting implementation
     if any(sort_null_first) is False and all(sort_ascending) is True:
         try:
-            return multi_col_sort(df, sort_columns, sort_ascending,
-                    sort_null_first)
+            return multi_col_sort(df, sort_columns, sort_ascending, sort_null_first)
         except NotImplementedError:
             pass
-
 
     # Split the first column. We need to handle this one with set_index
     first_sort_column = sort_columns[0]

--- a/tests/integration/fixtures.py
+++ b/tests/integration/fixtures.py
@@ -9,6 +9,11 @@ from dask.datasets import timeseries
 from dask.distributed import Client
 from pandas.testing import assert_frame_equal
 
+try:
+    import dask_cudf
+except ImportError:
+    dask_cudf = None
+
 
 @pytest.fixture()
 def timeseries_df(c):
@@ -117,6 +122,9 @@ def c(
     for df_name, df in dfs.items():
         dask_df = dd.from_pandas(df, npartitions=3)
         c.create_table(df_name, dask_df)
+        if dask_cudf is not None:
+            cudf_df = dask_cudf.from_dask_dataframe(dask_df)
+            c.create_table("cudf_" + df_name, cudf_df)
 
     yield c
 

--- a/tests/integration/test_dask_cudf.py
+++ b/tests/integration/test_dask_cudf.py
@@ -1,8 +1,8 @@
-import pandas as pd
 import pytest
-from pandas.testing import assert_frame_equal
 
 pytest.importorskip("dask_cudf")
+
+from cudf.testing._utils import assert_eq
 
 
 def test_cudf_order_by(c):
@@ -13,10 +13,18 @@ def test_cudf_order_by(c):
     FROM cudf_user_table_1
     ORDER BY user_id
     """
-    )
-    df = df.compute().to_pandas()
+    ).compute()
 
-    expected_df = pd.DataFrame(
-        {"user_id": [2, 1, 2, 3], "b": [3, 3, 1, 3]}
-    ).sort_values(by="user_id")
-    assert_frame_equal(df, expected_df)
+    expected_df = (
+        c.sql(
+            """
+    SELECT
+        *
+    FROM cudf_user_table_1
+    """
+        )
+        .sort_values(by="user_id", ignore_index=True)
+        .compute()
+    )
+
+    assert_eq(df, expected_df)

--- a/tests/integration/test_dask_cudf.py
+++ b/tests/integration/test_dask_cudf.py
@@ -1,0 +1,22 @@
+import pandas as pd
+import pytest
+from pandas.testing import assert_frame_equal
+
+pytest.importorskip("dask_cudf")
+
+
+def test_cudf_order_by(c):
+    df = c.sql(
+        """
+    SELECT
+        *
+    FROM cudf_user_table_1
+    ORDER BY user_id
+    """
+    )
+    df = df.compute().to_pandas()
+
+    expected_df = pd.DataFrame(
+        {"user_id": [2, 1, 2, 3], "b": [3, 3, 1, 3]}
+    ).sort_values(by="user_id")
+    assert_frame_equal(df, expected_df)

--- a/tests/integration/test_show.py
+++ b/tests/integration/test_show.py
@@ -2,6 +2,11 @@ import pandas as pd
 import pytest
 from pandas.testing import assert_frame_equal
 
+try:
+    import dask_cudf
+except ImportError:
+    dask_cudf = None
+
 
 def test_schemas(c):
     df = c.sql("SHOW SCHEMAS")
@@ -35,6 +40,27 @@ def test_tables(c):
                 "user_table_nan",
                 "string_table",
                 "datetime_table",
+            ]
+            if dask_cudf is None
+            else [
+                "df_simple",
+                "cudf_df_simple",
+                "df",
+                "cudf_df",
+                "user_table_1",
+                "cudf_user_table_1",
+                "user_table_2",
+                "cudf_user_table_2",
+                "long_table",
+                "cudf_long_table",
+                "user_table_inf",
+                "cudf_user_table_inf",
+                "user_table_nan",
+                "cudf_user_table_nan",
+                "string_table",
+                "cudf_string_table",
+                "datetime_table",
+                "cudf_datetime_table",
             ]
         }
     )


### PR DESCRIPTION
Adds an optional fast path for multi-column sorting when the following is true:

- dask-cudf is installed
- we are trying to sort a dask-cudf dataframe
- all columns are being sorted in ascending order with nulls positioned last

There's some work in dask-cudf aiming to support descending sort and null positioning, which could potentially open up the cases the fast path can be used:

- https://github.com/rapidsai/cudf/pull/9250
- https://github.com/rapidsai/cudf/pull/9264
