### PR TITLE
Update GHA workflows for use with RAPIDS fork

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -8,6 +8,8 @@ jobs:
   deploy:
     name: Deploy
     runs-on: ubuntu-latest
+    if: github.repository == `dask-contrib/dask-sql`
+
     steps:
       - uses: actions/checkout@v2
       - name: Cache local Maven repository

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -11,6 +11,8 @@ jobs:
   push_to_registry:
     name: Push Docker image to Docker Hub
     runs-on: ubuntu-latest
+    if: github.repository == 'dask-contrib/dask-sql'
+
     steps:
       - name: Check out the repo
         uses: actions/checkout@v2

--- a/.github/workflows/stylecheck.yml
+++ b/.github/workflows/stylecheck.yml
@@ -2,6 +2,12 @@
 name: Python Style Check
 on: [pull_request]
 
+# When this workflow is queued, automatically cancel any previous running
+# or pending jobs from the same branch
+concurrency:
+  group: ${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   pre-commit:
     runs-on: ubuntu-latest

--- a/.github/workflows/stylecheck.yml
+++ b/.github/workflows/stylecheck.yml
@@ -5,7 +5,7 @@ on: [pull_request]
 # When this workflow is queued, automatically cancel any previous running
 # or pending jobs from the same branch
 concurrency:
-  group: ${{ github.ref }}
+  group: style-${{ github.head_ref }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -6,7 +6,7 @@ name: Test
 on:
   push:
     branches:
-      - main
+      - branch-21.12
   pull_request:
 
 jobs:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -131,11 +131,11 @@ jobs:
           path: junit/test-results.xml
         # Use always() to always run this step to publish test results when there are test failures
         if: ${{ always() }}
-      - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@v2
-        with:
-          fail_ci_if_error: true
-          token: ${{ secrets.CODECOV_TOKEN }}
+      # - name: Upload coverage to Codecov
+      #   uses: codecov/codecov-action@v2
+      #   with:
+      #     fail_ci_if_error: true
+      #     token: ${{ secrets.CODECOV_TOKEN }}
   test_independent:
     name: "Test in a dask cluster"
     needs: build

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,7 +12,7 @@ on:
 # When this workflow is queued, automatically cancel any previous running
 # or pending jobs from the same branch
 concurrency:
-  group: ${{ github.ref }}
+  group: test-${{ github.head_ref }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,6 +9,12 @@ on:
       - branch-21.12
   pull_request:
 
+# When this workflow is queued, automatically cancel any previous running
+# or pending jobs from the same branch
+concurrency:
+  group: ${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   build:
     # This build step should be similar to the deploy build, to make sure we actually test

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -99,6 +99,7 @@ jobs:
           # explicitly install docker, fugue and other packages
           mamba install \
             sqlalchemy>=1.4.23 \
+            sasl>=0.3.1 \
             pyhive>=0.6.4 \
             psycopg2>=2.9.1 \
             ciso8601>=2.2.0 \


### PR DESCRIPTION
Updates the dask-sql workflows to fit our dev pattern:

- Workflows publishing to Docker or PyPI have been disabled for this fork
- Python testing has been retargeted to `branch-21.12`
- CodeCov has been disabled (for now, might be able to re-enable it later on)
- In-progress CI jobs will be cancelled if a new commit is pushed to a PR, matching gpuCI's behavior