### PR TITLE
Bump `RAPIDS_VER` for gpuCI

### DIFF
--- a/continuous_integration/gpuci/axis.yaml
+++ b/continuous_integration/gpuci/axis.yaml
@@ -8,6 +8,6 @@ LINUX_VER:
 - ubuntu18.04
 
 RAPIDS_VER:
-- "21.10"
+- "21.12"
 
 excludes:


### PR DESCRIPTION
With images built for cudf 21.12 / ucx-py 0.23, we are safe to bump the RAPIDS version running on gpuCI