### PR TITLE
Fix undetected GPU pytest marker

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -5,3 +5,5 @@ addopts =
     --cov-report=term-missing
 testpaths =
     tests
+markers =
+    gpu: marks tests that require GPUs (skipped by default, run with '--rungpu')

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,3 +1,0 @@
-[tool:pytest]
-markers:
-  gpu: marks tests we want to run on GPUs


### PR DESCRIPTION
Didn't notice that this repo has a `pytest.ini`; the GPU marker should be defined there instead of in `setup.cfg` so that it is picked up properly by pytest.