### PR TITLE
Upload nightlies to RAPIDS nightly channel

### DIFF
--- a/.github/workflows/conda.yml
+++ b/.github/workflows/conda.yml
@@ -2,7 +2,7 @@ name: Build conda nightly
 on:
   push:
     branches:
-      - main
+      - branch-22.02
   pull_request:
 
 # When this workflow is queued, automatically cancel any previous running

--- a/.github/workflows/conda.yml
+++ b/.github/workflows/conda.yml
@@ -51,7 +51,7 @@ jobs:
           && github.ref == 'refs/heads/main'
           && github.repository == 'dask-contrib/dask-sql'
         env:
-          ANACONDA_API_TOKEN: ${{ secrets.DASK_CONDA_TOKEN }}
+          ANACONDA_API_TOKEN: ${{ secrets.CONDA_RAPIDSAI_NIGHTLY_TOKEN }}
         run: |
           # install anaconda for upload
           mamba install anaconda-client

--- a/.github/workflows/conda.yml
+++ b/.github/workflows/conda.yml
@@ -48,8 +48,8 @@ jobs:
       - name: Upload conda package
         if: |
           github.event_name == 'push'
-          && github.ref == 'refs/heads/main'
-          && github.repository == 'dask-contrib/dask-sql'
+          && github.ref == 'refs/heads/branch-22.02'
+          && github.repository == 'rapidsai/dask-sql'
         env:
           ANACONDA_API_TOKEN: ${{ secrets.CONDA_RAPIDSAI_NIGHTLY_TOKEN }}
         run: |

--- a/.github/workflows/conda.yml
+++ b/.github/workflows/conda.yml
@@ -56,4 +56,4 @@ jobs:
           # install anaconda for upload
           mamba install anaconda-client
 
-          anaconda upload --label dev linux-64/*.tar.bz2
+          anaconda upload linux-64/*.tar.bz2


### PR DESCRIPTION
Uses the Anaconda token for the `rapidsai-nightly` channel to upload nightly conda builds, as the Dask channel token is no longer available. 